### PR TITLE
Set up repository to be installable as a theme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,3 @@
-MIT License
+We use a shared copyright model that enables all contributors to maintain the copyright on their contributions.
 
-Copyright (c) 2018 JupyterHub
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+All code is licensed under the terms of the revised BSD license.

--- a/alabaster_jupyterhub/__init__.py
+++ b/alabaster_jupyterhub/__init__.py
@@ -1,0 +1,21 @@
+import os
+
+from alabaster_jupyterhub import _version as version
+
+
+with open(os.path.join(os.path.dirname(__file__), "_version.py")) as fp:
+    exec(fp.read(), None, {})
+
+def get_path():
+    """
+    Shortcut for users whose theme is next to their conf.py.
+    """
+    # Theme directory is defined as our parent directory
+    return os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+def setup(app):
+    # add_html_theme is new in Sphinx 1.6+
+    if hasattr(app, "add_html_theme"):
+        theme_path = os.path.abspath(os.path.dirname(__file__))
+        app.add_html_theme("alabaster_jupyterhub", theme_path)
+    return {"version": version.__version__, "parallel_read_safe": True}

--- a/alabaster_jupyterhub/__init__.py
+++ b/alabaster_jupyterhub/__init__.py
@@ -1,7 +1,9 @@
+"""The JupyterHub Alabaster theme"""
 import os
 
 from alabaster_jupyterhub import _version as version
 
+__version__ = version.__version__
 
 with open(os.path.join(os.path.dirname(__file__), "_version.py")) as fp:
     exec(fp.read(), None, {})

--- a/alabaster_jupyterhub/_version.py
+++ b/alabaster_jupyterhub/_version.py
@@ -1,0 +1,2 @@
+__version_info__ = (0, 1, 1)
+__version__ = ".".join(map(str, __version_info__))

--- a/alabaster_jupyterhub/_version.py
+++ b/alabaster_jupyterhub/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 1, 1)
+__version_info__ = (0, 1, 2, 'dev')
 __version__ = ".".join(map(str, __version_info__))

--- a/alabaster_jupyterhub/layout.html
+++ b/alabaster_jupyterhub/layout.html
@@ -1,0 +1,7 @@
+{%- extends "basic/layout.html" %}
+
+{%- block extrahead %}
+  {{ super() }}
+  <!-- Add JupyterHub styling -->
+  <link rel="stylesheet" href="{{ pathto('_static/jupyter.css', 1) }}" type="text/css" />
+{% endblock %}

--- a/alabaster_jupyterhub/theme.conf
+++ b/alabaster_jupyterhub/theme.conf
@@ -1,0 +1,2 @@
+[theme]
+inherit = alabaster

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+alabaster
+sphinx
+
+# Install ourselves direct, even when being used on eg RTD. Otherwise we can't
+# dogfood our own changes until release to PyPI.
+-e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["flit"]
+build-backend = "flit.buildapi"
+
+[tool.flit.metadata]
+module = "alabaster_jupyterhub"
+author = "Project Jupyter"
+author-email = "jupyter@googlegroups.com"
+home-page = "https://github.com/jupyterhub/alabaster-jupyterhub"
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import codecs
+from setuptools import setup
+
+# Version info -- read without importing
+_locals = {}
+with open("alabaster_jupyterhub/_version.py") as fp:
+    exec(fp.read(), None, _locals)
+version = _locals["__version__"]
+
+setup(
+    name="alabaster_jupyterhub",
+    version=version,
+    description="A configurable sidebar-enabled Sphinx theme for Project Jupyter",
+    author="Project Jupyter",
+    author_email="jupyter@googlegroups.org",
+    url="https://github.com/jupyterhub/alabaster-jupyterhub",
+    packages=["alabaster_jupyterhub"],
+    include_package_data=True,
+    entry_points={"sphinx.html_themes": ["alabaster_jupyterhub = alabaster_jupyterhub"]},
+)


### PR DESCRIPTION
This sets up a super lightweight theme for JupyterHub to use in its pages. Currently all it does is add a little bit of extra CSS. If we want to expand it in the future, we can update the templates here and they'll be based off of the Alabaster theme.