### PR TITLE
Update import parameters and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # alabaster-jupyterhub
-A slight modification of the Alabaster theme for use with JupyterHub projects
+
+A Sphinx theme used by the JupyterHub org projects. It is a slight modification
+of the Alabaster theme.
+
+## Installation
+
+```
+pip install alabaster_jupyterhub
+```
+
+## Configuration
+
+In `conf.py`, add the following lines:
+
+```
+import alabaster_jupyterhub
+
+...
+
+html_theme = 'alabaster_jupyterhub'
+html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
+
+...
+
+# If you have a RTD check, make sure to set theme
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if not on_rtd:
+    html_theme = 'alabaster_jupyterhub'
+    html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
+```

--- a/alabaster_jupyterhub/__init__.py
+++ b/alabaster_jupyterhub/__init__.py
@@ -15,6 +15,14 @@ def get_path():
     # Theme directory is defined as our parent directory
     return os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
+def get_html_theme_path():
+    """
+    Utility to return theme location.
+    Used in Sphinx conf.py to set html_theme_path.
+    """
+    # Theme directory is defined as our parent directory
+    return os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
 def setup(app):
     # add_html_theme is new in Sphinx 1.6+
     if hasattr(app, "add_html_theme"):

--- a/alabaster_jupyterhub/layout.html
+++ b/alabaster_jupyterhub/layout.html
@@ -1,7 +1,7 @@
-{%- extends "basic/layout.html" %}
+{%- extends "alabaster/layout.html" %}
 
 {%- block extrahead %}
-  {{ super() }}
-  <!-- Add JupyterHub styling -->
-  <link rel="stylesheet" href="{{ pathto('_static/jupyter.css', 1) }}" type="text/css" />
+{{ super() }}
+<!-- Add JupyterHub styling -->
+<link rel="stylesheet" href="{{ pathto('_static/jupyter.css', 1) }}" type="text/css" />
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,8 @@ setup(
     packages=["alabaster_jupyterhub"],
     include_package_data=True,
     entry_points={"sphinx.html_themes": ["alabaster_jupyterhub = alabaster_jupyterhub"]},
+    install_requires=[
+       'sphinx',
+       'alabaster',
+    ]
 )


### PR DESCRIPTION
- add guidance for conf.py configuration in README
- install requires alabaster
- extend layout from alabaster instead of basic
- add a utility function `get_html_theme_path` to match the typical usage in sphinx `conf.py` (functionality is the same as `get_path`