### PR TITLE
[MRG] adding right sidebar

### DIFF
--- a/alabaster_jupyterhub/layout.html
+++ b/alabaster_jupyterhub/layout.html
@@ -5,3 +5,7 @@
 <!-- Add JupyterHub styling -->
 <link rel="stylesheet" href="{{ pathto('_static/jupyter.css', 1) }}" type="text/css" />
 {% endblock %}
+
+{% block sidebar1 %}
+{%- include "rightsidebar.html" %}
+{% endblock %}

--- a/alabaster_jupyterhub/rightsidebar.html
+++ b/alabaster_jupyterhub/rightsidebar.html
@@ -1,0 +1,4 @@
+<div class="rightsidebar">
+    <h3>On this page</h3>
+    {{ toc }}
+</div>

--- a/alabaster_jupyterhub/static/jupyter.css
+++ b/alabaster_jupyterhub/static/jupyter.css
@@ -12,3 +12,59 @@ div.sphinxsidebarwrapper ul {
     font-size: .8em;
     padding-left: 1em;
 }
+
+/* Right sidebar */
+@media screen and (min-width: 875px) {
+    div.body {
+        /* To allow room for sidebar */
+        max-width: 700px;
+    }
+
+    div.document {
+        width: 1160px;
+    }
+}
+
+
+
+@media screen and (min-width: 875px) {
+    div.rightsidebar {
+        /* Positioning */
+        display: block;
+        width: 220px;
+        position: fixed;
+        top: 72px;
+        right: 0;
+        padding-right: 24px;
+        z-index: 1;
+        left: 50%;
+        transform: translateX(400px);
+    }
+}
+
+@media screen and (max-width: 875px) {
+    div.rightsidebar {
+        display: none;
+    }
+}
+
+div.rightsidebar {
+    /* Font text */
+    font-size: .8em;
+    color: #444;
+    text-decoration: none;
+}
+
+div.rightsidebar a {
+    color: #444;
+    text-decoration: none;
+    border-bottom: none;
+}
+
+div.rightsidebar ul, ol {
+    margin: 5px 0 5px 30px;
+}
+
+div.rightsidebar ul, ol {
+    margin: 5px 0 5px 15px;
+}

--- a/alabaster_jupyterhub/static/jupyter.css
+++ b/alabaster_jupyterhub/static/jupyter.css
@@ -4,6 +4,10 @@ div.body p.caption {
 }
 
 /* Sidebar */
+div.sphinxsidebarwrapper h1 {
+    font-size: 1.8em;
+}
+
 div.sphinxsidebarwrapper p.caption {
     font-size: 1.4em;
 }
@@ -42,7 +46,7 @@ div.sphinxsidebarwrapper ul {
     }
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 1150px) {
     div.rightsidebar {
         display: none;
     }
@@ -67,4 +71,8 @@ div.rightsidebar ul, ol {
 
 div.rightsidebar ul, ol {
     margin: 5px 0 5px 15px;
+}
+
+div.rightsidebar li {
+    margin: 3px 0px 3px 0px;
 }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ This is a demo for the changes we make to the Alabaster theme. If
 any new changes are added, we can preview them here. Anything that's *not*
 explicitly demoed should be assumed to be the same as the Alabaster theme.
 
-Modifying the sidebar and body captions 
+Modifying the sidebar and body captions
 =======================================
 
 We often use the ``toctree`` "caption" argument to add a small caption header
@@ -29,3 +29,35 @@ in-line captions.
 
    foo <https://jupyter.org/>
    bar <https://jupyter.org/>
+
+
+Lorem Ipsum
+===========
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus eget ipsum blandit,
+tristique velit quis, aliquam libero. Sed vitae accumsan tortor, vitae vulputate tellus.
+Sed sed lacus mauris. Duis efficitur, tellus maximus fermentum faucibus, tellus sapien
+ornare arcu, ac vulputate ante erat a arcu. Praesent maximus nisl eget est tincidunt,
+non suscipit metus volutpat. Quisque volutpat lectus id arcu volutpat molestie. Integer
+tincidunt lorem et lobortis cursus.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus eget ipsum blandit,
+tristique velit quis, aliquam libero. Sed vitae accumsan tortor, vitae vulputate tellus.
+Sed sed lacus mauris. Duis efficitur, tellus maximus fermentum faucibus, tellus sapien
+ornare arcu, ac vulputate ante erat a arcu. Praesent maximus nisl eget est tincidunt,
+non suscipit metus volutpat. Quisque volutpat lectus id arcu volutpat molestie. Integer
+tincidunt lorem et lobortis cursus.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus eget ipsum blandit,
+tristique velit quis, aliquam libero. Sed vitae accumsan tortor, vitae vulputate tellus.
+Sed sed lacus mauris. Duis efficitur, tellus maximus fermentum faucibus, tellus sapien
+ornare arcu, ac vulputate ante erat a arcu. Praesent maximus nisl eget est tincidunt,
+non suscipit metus volutpat. Quisque volutpat lectus id arcu volutpat molestie. Integer
+tincidunt lorem et lobortis cursus.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus eget ipsum blandit,
+tristique velit quis, aliquam libero. Sed vitae accumsan tortor, vitae vulputate tellus.
+Sed sed lacus mauris. Duis efficitur, tellus maximus fermentum faucibus, tellus sapien
+ornare arcu, ac vulputate ante erat a arcu. Praesent maximus nisl eget est tincidunt,
+non suscipit metus volutpat. Quisque volutpat lectus id arcu volutpat molestie. Integer
+tincidunt lorem et lobortis cursus.


### PR DESCRIPTION
This adds an "on this page" sidebar to the right of each page with internal links. This does the following:

* Add `localtoc.html` content in a sidebar to the right
* Slight modifications to page layout to make sure there's room for this content

If the screen becomes too narrow, then it simply hides the localtoc content.

Here's a GIF of what this looks like for the Z2JH docs:

![2019-01-16_10-33-40](https://user-images.githubusercontent.com/1839645/51270596-36f15180-197a-11e9-89d2-9ab74bf17ca0.gif)
